### PR TITLE
Reworked `Engine` texture loading patterns

### DIFF
--- a/Sources/TiledKit/Game Engines/Engine.swift
+++ b/Sources/TiledKit/Game Engines/Engine.swift
@@ -61,8 +61,12 @@ public protocol Engine {
     /// Register any default factories or post-processors
     static func registerProducers()
     
-    /// Provide a method for loading textures
-    static func load(textureFrom url:URL, in project:Project) throws -> TextureType
+    /// Provide a method for loading textures, should not be called directly as it is intended to provide a point for a specific `Engine`
+    /// specialization to provide concrete low-level loading behaviour.
+    /// - Parameters:
+    ///   - url: The location of the image
+    ///   - loader: The loader object, this will be supplied by the `Engine` (not a specific implementation of it).
+    static func load<LoaderType:EngineImageLoader>(textureFrom url:URL, by loader:LoaderType) throws -> TextureType
 
     /// Make an instance of a given texture given the supplied clipping bounds and properites for this instance
     static func make(texture:TextureType, with bounds:PixelBounds?, and properties:Properties, in project:Project) throws -> TextureType

--- a/Sources/TiledKit/Game Engines/EngineTexture.swift
+++ b/Sources/TiledKit/Game Engines/EngineTexture.swift
@@ -23,6 +23,16 @@ public extension Engine {
         
         return try make(texture: texture, with: bounds, and: properties, in: project)
     }
+    
+    /// Loads a texture (through the `Engine`'s specific implementation of image loading (ensuring caching is performed etc)
+    /// - Parameters:
+    ///   - url: The source of the texture
+    ///   - project: The project (providing context about the location of the image which may be needed)
+    /// - Throws: Any errors during loading
+    /// - Returns: The specific texture type for the image
+    static func load(textureFrom url:URL, in project:Project) throws -> TextureType {
+        return try project.retrieve(asType: TextureType.self, from: url)
+    }
 }
 
 /// By implementing this protocol (required for `Engine.TextureType`

--- a/Sources/TiledKit/Game Engines/Loaders/EngineTextureLoader.swift
+++ b/Sources/TiledKit/Game Engines/Loaders/EngineTextureLoader.swift
@@ -14,7 +14,14 @@
 
 import Foundation
 
-class EngineTextureLoader<EngineType:Engine> : ResourceLoader {
+/// This type should not be implemented outside of TiledKit and is used solely pass
+/// information about the current project to the `Engine`s load texture implementation.
+/// Outside of TiledKit you should use the automatically provided `Engine.load(textureFrom url:URL, project: Project)` method
+public protocol EngineImageLoader {
+    var project: Project { get }
+}
+
+class EngineTextureLoader<EngineType:Engine> : ResourceLoader, EngineImageLoader {
     let project : Project
     
     init(_ project:Project){
@@ -22,7 +29,7 @@ class EngineTextureLoader<EngineType:Engine> : ResourceLoader {
     }
     
     func retrieve<R>(asType: R.Type, from url: URL) throws -> R where R : Loadable {
-        guard let loadedTexture =  try EngineType.load(textureFrom: url, in: project) as? R else {
+        guard let loadedTexture =  try EngineType.load(textureFrom: url, by: self) as? R else {
             throw EngineError.couldNotCreateTextureFrom(url)
         }
         return loadedTexture

--- a/Tests/TiledKitTests/TestEngine.swift
+++ b/Tests/TiledKitTests/TestEngine.swift
@@ -15,6 +15,10 @@
 import Foundation
 import TiledKit
 
+enum TestEngineError : Error {
+    case incorrectLoaderUsed(loaderType:String)
+}
+
 final class TestEngine : Engine {
     typealias FloatType = Float
     typealias ColorType = UInt32
@@ -31,7 +35,11 @@ final class TestEngine : Engine {
     typealias PolylineObjectType = TestPologonal
     typealias PolygonObjectType = TestPologonal
 
-    static func load(textureFrom url: URL, in project:Project) throws -> TestTexture {
+    static func load<LoaderType>(textureFrom url: URL, by loader: LoaderType) throws -> TestTexture where LoaderType : EngineImageLoader {
+        let loaderName = "\(type(of: loader))"
+        guard loaderName.hasPrefix("EngineTextureLoader") else {
+            throw TestEngineError.incorrectLoaderUsed(loaderType: loaderName)
+        }
         return TestTexture(from: url)
     }
     


### PR DESCRIPTION
Previous implementation was too easy to accidentally misuse and not get the benefits of caching etc.